### PR TITLE
[DEV] 감정 정보 api 구현

### DIFF
--- a/src/main/java/com/example/aneukbeserver/controller/EmotionController.java
+++ b/src/main/java/com/example/aneukbeserver/controller/EmotionController.java
@@ -1,0 +1,62 @@
+package com.example.aneukbeserver.controller;
+
+
+import com.example.aneukbeserver.auth.dto.StatusResponseDto;
+import com.example.aneukbeserver.auth.jwt.JwtUtil;
+import com.example.aneukbeserver.domain.emotion.EmotionRepository;
+import com.example.aneukbeserver.domain.emotion.EmotionResponseDTO;
+import com.example.aneukbeserver.domain.member.Member;
+import com.example.aneukbeserver.domain.member.MemberRepository;
+import com.example.aneukbeserver.service.EmotionService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Optional;
+
+import static com.example.aneukbeserver.auth.dto.StatusResponseDto.addStatus;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/emotion")
+@Tag(name = "Emotion Controller", description = "감정 정보를 가져오는 컨트롤러")
+public class EmotionController {
+
+    @Autowired
+    private EmotionService emotionService;
+
+    @Autowired
+    private JwtUtil jwtUtil;
+
+    @Autowired
+    private MemberRepository memberService;
+
+
+    @Operation(summary = "감정 정보 가져오기", description = "id에 따른 감정 정보를 가져옵니다")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 에러, 관리자에게 문의 바랍니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "사용자가 존재하지 않습니다.")
+    })
+    @GetMapping("/{id}")
+    public ResponseEntity<StatusResponseDto> getEmotionInfo(@Parameter(hidden = true) @RequestHeader("Authorization") final String accessToken, @PathVariable Long id) {
+        String userEmail = jwtUtil.getEmail(accessToken.substring(7));
+        Optional<Member> member = memberService.findByEmail(userEmail);
+        if (member.isEmpty())
+            return ResponseEntity.badRequest().body(addStatus(400, "사용자가 존재하지 않습니다."));
+
+        EmotionResponseDTO emotionResponseDTO = emotionService.getEmotionInfo(id);
+
+        if (emotionResponseDTO == null)
+            return ResponseEntity.badRequest().body(addStatus(401, "해당하는 감정 정보가 존재하지 않습니다"));
+
+        return ResponseEntity.ok(addStatus(200, emotionResponseDTO));
+    }
+}

--- a/src/main/java/com/example/aneukbeserver/domain/emotion/EmotionResponseDTO.java
+++ b/src/main/java/com/example/aneukbeserver/domain/emotion/EmotionResponseDTO.java
@@ -1,0 +1,16 @@
+package com.example.aneukbeserver.domain.emotion;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class EmotionResponseDTO {
+    private Long emotion_id;
+    private String emotion_name;
+    private String description;
+}

--- a/src/main/java/com/example/aneukbeserver/service/EmotionService.java
+++ b/src/main/java/com/example/aneukbeserver/service/EmotionService.java
@@ -1,0 +1,30 @@
+package com.example.aneukbeserver.service;
+
+import com.example.aneukbeserver.domain.emotion.Emotion;
+import com.example.aneukbeserver.domain.emotion.EmotionRepository;
+import com.example.aneukbeserver.domain.emotion.EmotionResponseDTO;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+public class EmotionService {
+    @Autowired
+    private EmotionRepository emotionRepository;
+
+    public EmotionResponseDTO getEmotionInfo(Long id) {
+        Optional<Emotion> emotion = emotionRepository.findById(id);
+
+        if(emotion.isEmpty()) return null;
+
+        EmotionResponseDTO emotionResponseDTO = new EmotionResponseDTO();
+        emotionResponseDTO.setEmotion_id(id);
+        emotionResponseDTO.setEmotion_name(emotion.get().getTitle());
+        emotionResponseDTO.setDescription(emotion.get().getExample());
+
+        return emotionResponseDTO;
+
+
+    }
+}


### PR DESCRIPTION
## summary
감정 정보 api 구현

## description
/emotion/{id}를 통해 감정 설명 가져오기
- 성공했을 시
{
  "status": 200,
  "data": {
    "emotion_id": 3,
    "emotion_name": "급박하다",
    "description": null
  }
}

- 실패했을 시
{
  "status": 401,
  "data": "해당하는 감정 정보가 존재하지 않습니다"
}