### PR TITLE
[DEV] Emotion Controller & First Diary generate 수정

### DIFF
--- a/src/main/java/com/example/aneukbeserver/domain/diary/DiaryFirstResponseDTO.java
+++ b/src/main/java/com/example/aneukbeserver/domain/diary/DiaryFirstResponseDTO.java
@@ -1,0 +1,10 @@
+package com.example.aneukbeserver.domain.diary;
+
+import com.example.aneukbeserver.domain.diaryParagraph.SaveDiaryParagraphDTO;
+
+import java.util.List;
+
+public class DiaryFirstResponseDTO {
+    private Long chat_id;
+    private List<SaveDiaryParagraphDTO> content_list;
+}

--- a/src/main/java/com/example/aneukbeserver/domain/diaryParagraph/DiaryParagraphDTO.java
+++ b/src/main/java/com/example/aneukbeserver/domain/diaryParagraph/DiaryParagraphDTO.java
@@ -1,0 +1,13 @@
+package com.example.aneukbeserver.domain.diaryParagraph;
+
+import com.example.aneukbeserver.domain.emotion.EmotionDTO;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class DiaryParagraphDTO {
+    private int order_index;
+    private String original_content;
+    private List<EmotionDTO> recommend_emotion;
+}

--- a/src/main/java/com/example/aneukbeserver/domain/diaryParagraph/SelectParagraphDTO.java
+++ b/src/main/java/com/example/aneukbeserver/domain/diaryParagraph/SelectParagraphDTO.java
@@ -14,5 +14,7 @@ import java.util.List;
 @NoArgsConstructor
 public class SelectParagraphDTO{
     private Long diary_id;
-    private List<SaveDiaryParagraphDTO> content_list;
+    private List<DiaryParagraphDTO> content_list;
 }
+
+

--- a/src/main/java/com/example/aneukbeserver/domain/emotion/Emotion.java
+++ b/src/main/java/com/example/aneukbeserver/domain/emotion/Emotion.java
@@ -16,5 +16,8 @@ public class Emotion {
     private String title;
 
     @Column
+    private String category;
+
+    @Column
     private String example;
 }

--- a/src/main/java/com/example/aneukbeserver/domain/emotion/EmotionDTO.java
+++ b/src/main/java/com/example/aneukbeserver/domain/emotion/EmotionDTO.java
@@ -1,0 +1,11 @@
+package com.example.aneukbeserver.domain.emotion;
+
+import lombok.Data;
+
+@Data
+public class EmotionDTO {
+    private Long id;
+    private String title;
+    private String category;
+    private String example;
+}

--- a/src/main/java/com/example/aneukbeserver/domain/emotion/EmotionRepository.java
+++ b/src/main/java/com/example/aneukbeserver/domain/emotion/EmotionRepository.java
@@ -2,5 +2,8 @@ package com.example.aneukbeserver.domain.emotion;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface EmotionRepository extends JpaRepository<Emotion, Long> {
+    Emotion findByTitle(String title);
 }

--- a/src/main/java/com/example/aneukbeserver/domain/emotion/EmotionResponseDTO.java
+++ b/src/main/java/com/example/aneukbeserver/domain/emotion/EmotionResponseDTO.java
@@ -12,5 +12,6 @@ import lombok.Setter;
 public class EmotionResponseDTO {
     private Long emotion_id;
     private String emotion_name;
+    private String category;
     private String description;
 }

--- a/src/main/java/com/example/aneukbeserver/service/EmotionService.java
+++ b/src/main/java/com/example/aneukbeserver/service/EmotionService.java
@@ -26,6 +26,7 @@ public class EmotionService {
         emotionResponseDTO.setEmotion_id(id);
         emotionResponseDTO.setEmotion_name(emotion.get().getTitle());
         emotionResponseDTO.setDescription(emotion.get().getExample());
+        emotionResponseDTO.setCategory(emotion.get().getCategory());
 
         return emotionResponseDTO;
     }

--- a/src/main/java/com/example/aneukbeserver/service/EmotionService.java
+++ b/src/main/java/com/example/aneukbeserver/service/EmotionService.java
@@ -1,12 +1,16 @@
 package com.example.aneukbeserver.service;
 
 import com.example.aneukbeserver.domain.emotion.Emotion;
+import com.example.aneukbeserver.domain.emotion.EmotionDTO;
 import com.example.aneukbeserver.domain.emotion.EmotionRepository;
 import com.example.aneukbeserver.domain.emotion.EmotionResponseDTO;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 public class EmotionService {
@@ -24,7 +28,26 @@ public class EmotionService {
         emotionResponseDTO.setDescription(emotion.get().getExample());
 
         return emotionResponseDTO;
-
-
     }
+
+    public List<EmotionDTO> getEmotionDetail(List<String> titles) {
+        List<EmotionDTO> emotions = titles.stream()
+                .map(title -> {
+                    Emotion emotion = emotionRepository.findByTitle(title);
+                    if (emotion == null) {
+                        return null; // 존재하지 않는 경우 처리
+                    }
+                    EmotionDTO emotionDTO = new EmotionDTO();
+                    emotionDTO.setId(emotion.getId());
+                    emotionDTO.setExample(emotion.getExample());
+                    emotionDTO.setCategory(emotion.getCategory());
+                    emotionDTO.setTitle(emotion.getTitle());
+                    return emotionDTO;
+                })
+                .filter(Objects::nonNull) // null 제거 (옵션)
+                .collect(Collectors.toList());
+        return emotions;
+    }
+
+
 }


### PR DESCRIPTION
## summary
- 감정 정보 api 와 첫번째 일기를 생성하여 추천 감정을 response해주는 부분을 수정했습니다

## description
- id를 통해 감정 정보를 검색할 때 카테고리를 주가해습니다.
<img width="277" alt="image" src="https://github.com/user-attachments/assets/d4e0c9c7-fc8a-4772-8a8c-7eec2252ec52">

- 문단별로 감정 단어를 추천하는 과정에서 id와 category, example을 모두함께 반환하도록 했습니다
```
{
  "status": 200,
  "data": {
    "diary_id": 3,
    "content_list": [
      {
        "order_index": 0,
        "original_content": "오늘 처음으로 랩미팅에 참여했다. 처음이라 그런지 조금 떨렸지만 생각보다 할 만했다.",
        "recommend_emotion": [
          {
            "id": 22,
            "title": "안절부절하다",
            "category": "공포",
            "example": null
          },
          {
            "id": 5,
            "title": "긴장되다",
            "category": "공포",
            "example": null
          },
          {
            "id": 48,
            "title": "기쁘다",
            "category": "기쁨",
            "example": null
          },
    ...
}
```