### PR TITLE
[DEV] 감정 도감 API 구현

### DIFF
--- a/src/main/java/com/example/aneukbeserver/controller/StatisticsController.java
+++ b/src/main/java/com/example/aneukbeserver/controller/StatisticsController.java
@@ -2,9 +2,6 @@ package com.example.aneukbeserver.controller;
 
 import com.example.aneukbeserver.auth.dto.StatusResponseDto;
 import com.example.aneukbeserver.auth.jwt.JwtUtil;
-import com.example.aneukbeserver.domain.diary.Diary;
-import com.example.aneukbeserver.domain.diary.DiaryDTO;
-import com.example.aneukbeserver.domain.emotion.CategoryEmotionCount;
 import com.example.aneukbeserver.domain.member.Member;
 import com.example.aneukbeserver.service.*;
 import io.swagger.v3.oas.annotations.Operation;
@@ -42,14 +39,7 @@ public class StatisticsController {
     private EmotionService emotionService;
 
     @Autowired
-    private ChatService chatService;
-
-    @Autowired
-    private ChatMessagesService chatMessagesService;
-
-    @Autowired
-    private DiaryService diaryService;
-
+    private CollectionService collectionService;
 
     @Operation(summary = "최근 30일 통계", description = "최근 30일의 감정들의 개수를 카테고리마다 보여줍니다")
     @ApiResponses(value = {
@@ -68,6 +58,28 @@ public class StatisticsController {
             return ResponseEntity.badRequest().body(addStatus(400, "사용자가 존재하지 않습니다."));
 
         Map<String, Long> stats = emotionService.get30daysEmotionCategory(member.get());
+
+        return ResponseEntity.ok().body(addStatus(200, stats));
+
+    }
+
+    @Operation(summary = "감정도감", description = "사용한 감정/전체 감정, 각 카테고리별 사용한 감정/전체 감정을 보여줍니다")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 에러, 관리자에게 문의 바랍니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "사용자가 존재하지 않습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "일기가 존재하지 않습니다.")
+
+    })
+    @GetMapping("/collection")
+    public ResponseEntity<StatusResponseDto> getEmotionCollection(@Parameter(hidden = true) @RequestHeader("Authorization") final String accessToken) {
+        String userEmail = jwtUtil.getEmail(accessToken.substring(7));
+        Optional<Member> member = memberService.findByEmail(userEmail);
+
+        if (member.isEmpty())
+            return ResponseEntity.badRequest().body(addStatus(400, "사용자가 존재하지 않습니다."));
+
+        Map<String, Object> stats = collectionService.getEmotionCollection(member.get());
 
         return ResponseEntity.ok().body(addStatus(200, stats));
 

--- a/src/main/java/com/example/aneukbeserver/domain/collection/Collection.java
+++ b/src/main/java/com/example/aneukbeserver/domain/collection/Collection.java
@@ -1,0 +1,27 @@
+package com.example.aneukbeserver.domain.collection;
+
+import com.example.aneukbeserver.domain.emotion.Emotion;
+import com.example.aneukbeserver.domain.member.Member;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+public class Collection {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name="member_id", nullable = false)
+    private Member member;
+
+    @ManyToOne
+    @JoinColumn(name="emotion_id", nullable = false)
+    private Emotion emotion;
+
+    @Column
+    private Long usageCount = 0L;
+}

--- a/src/main/java/com/example/aneukbeserver/domain/collection/CollectionRepository.java
+++ b/src/main/java/com/example/aneukbeserver/domain/collection/CollectionRepository.java
@@ -1,0 +1,15 @@
+package com.example.aneukbeserver.domain.collection;
+
+import com.example.aneukbeserver.domain.emotion.Emotion;
+import com.example.aneukbeserver.domain.member.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface CollectionRepository extends JpaRepository<Collection, Long> {
+
+    List<Collection> findByMember(Member member);
+
+    Optional<Collection> findByMemberAndEmotion(Member member, Emotion emotion);
+}

--- a/src/main/java/com/example/aneukbeserver/domain/emotion/CategoryEmotionCount.java
+++ b/src/main/java/com/example/aneukbeserver/domain/emotion/CategoryEmotionCount.java
@@ -1,5 +1,0 @@
-package com.example.aneukbeserver.domain.emotion;
-
-public class CategoryEmotionCount {
-
-}

--- a/src/main/java/com/example/aneukbeserver/domain/emotion/EmotionRepository.java
+++ b/src/main/java/com/example/aneukbeserver/domain/emotion/EmotionRepository.java
@@ -7,4 +7,6 @@ import java.util.Optional;
 
 public interface EmotionRepository extends JpaRepository<Emotion, Long> {
     Optional<Emotion> findByTitle(String title);
+
+    long countByCategory(String category);
 }

--- a/src/main/java/com/example/aneukbeserver/domain/emotion/SaveEmotionDTO.java
+++ b/src/main/java/com/example/aneukbeserver/domain/emotion/SaveEmotionDTO.java
@@ -1,0 +1,16 @@
+package com.example.aneukbeserver.domain.emotion;
+
+import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@Data
+public class SaveEmotionDTO {
+    private Long diary_id;
+    private Integer order_index;
+    private List<String> emotions;
+}

--- a/src/main/java/com/example/aneukbeserver/service/CollectionService.java
+++ b/src/main/java/com/example/aneukbeserver/service/CollectionService.java
@@ -1,0 +1,90 @@
+package com.example.aneukbeserver.service;
+
+import com.example.aneukbeserver.domain.collection.Collection;
+import com.example.aneukbeserver.domain.collection.CollectionRepository;
+import com.example.aneukbeserver.domain.diaryParagraph.DiaryParagraph;
+import com.example.aneukbeserver.domain.emotion.Emotion;
+import com.example.aneukbeserver.domain.emotion.EmotionRepository;
+import com.example.aneukbeserver.domain.member.Member;
+import com.example.aneukbeserver.domain.selectedEmotion.SelectedEmotion;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class CollectionService {
+
+    @Autowired
+    private CollectionRepository collectionRepository;
+
+    @Autowired
+    private EmotionRepository emotionRepository;
+
+
+    public Map<String, Object> getEmotionCollection(Member member) {
+        Map<String, Object> statistics = new HashMap<>();
+
+        long totalEmotions = emotionRepository.count(); // 혹시 감정이 추가될수도 있으니 ..
+
+        // 특정 멤버의 Collection
+        List<Collection> collections = collectionRepository.findByMember(member);
+
+        // 사용한 전체
+        long usedEmotions = collections.stream()
+                .map(collection -> collection.getEmotion().getId())
+                .distinct()
+                .count();
+
+        statistics.put("usedEmotionCount", usedEmotions);
+        statistics.put("totalEmotionCount", totalEmotions);
+
+        // 카테고리별
+        Map<String, Long> categoryUsageStats = collections.stream()
+                .collect(Collectors.groupingBy(
+                        collection -> collection.getEmotion().getCategory(),
+                        Collectors.counting()
+                ));
+
+        Map<String, Object> categoryStats = new HashMap<>();
+        for (Map.Entry<String, Long> entry : categoryUsageStats.entrySet()) {
+            String category = entry.getKey();
+            long count = entry.getValue();
+            long totalInCategory = emotionRepository.countByCategory(category);
+
+            categoryStats.put(category,  Map.of(
+                    "usedCount", count,
+                    "totalCount", totalInCategory
+            ));
+        }
+        statistics.put("categoryStats", categoryStats);
+
+        return statistics;
+    }
+
+    public void saveEmotionCollection(List<Emotion> emotionList, Member member) {
+        for (Emotion emotion : emotionList) {
+            Optional<Collection> existingCollection = collectionRepository.findByMemberAndEmotion(member, emotion);
+            if (existingCollection.isPresent()) {
+                Collection collection = existingCollection.get();
+                collection.setUsageCount(collection.getUsageCount() + 1);
+                collectionRepository.save(collection);
+            }
+            else {
+                Collection newCollection = new Collection();
+                newCollection.setMember(member);
+                newCollection.setEmotion(emotion);
+                newCollection.setUsageCount(1L);
+                collectionRepository.save(newCollection);
+            }
+        }
+
+
+    }
+}

--- a/src/main/java/com/example/aneukbeserver/service/DiaryService.java
+++ b/src/main/java/com/example/aneukbeserver/service/DiaryService.java
@@ -62,7 +62,7 @@ public class DiaryService {
                 .map(paragraph -> paragraph.getFinalContent() != null
                                 ? paragraph.getFinalContent()
                         : paragraph.getOriginalContent()
-                ).collect(Collectors.joining());
+                ).collect(Collectors.joining(" "));
     }
 
     public List<DiaryDTO> getAllDiary(Member member) {

--- a/src/main/java/com/example/aneukbeserver/service/SelectedEmotionService.java
+++ b/src/main/java/com/example/aneukbeserver/service/SelectedEmotionService.java
@@ -1,7 +1,10 @@
 package com.example.aneukbeserver.service;
 
+import com.example.aneukbeserver.domain.collection.Collection;
+import com.example.aneukbeserver.domain.collection.CollectionRepository;
 import com.example.aneukbeserver.domain.diaryParagraph.DiaryParagraph;
 import com.example.aneukbeserver.domain.emotion.Emotion;
+import com.example.aneukbeserver.domain.member.Member;
 import com.example.aneukbeserver.domain.selectedEmotion.SelectedEmotion;
 import com.example.aneukbeserver.domain.selectedEmotion.SelectedEmotionRepository;
 import lombok.RequiredArgsConstructor;
@@ -10,6 +13,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 public class SelectedEmotionService {
@@ -25,6 +29,8 @@ public class SelectedEmotionService {
             selectedEmotion.setEmotion(emotion);
             selectedEmotion.setDiaryParagraph(diaryParagraph);
             selectedEmotionRepository.save(selectedEmotion);
+
+
         }
     }
 


### PR DESCRIPTION
- 문장 합칠 때 띄어쓰기 추가했습니다

- 감정도감 구현을 위해 문장 remake와 감정 저장을 분리했습니다
- 문장 remake는 저장하는 부분 삭제를 제외하고는 변화 없습니다
- /diary/emotion/save를 통해 최종 선택된 감정들을 저장합니다
![image](https://github.com/user-attachments/assets/f4f710b5-5e9c-4095-a7ad-54de232abd60)
```
{
  "status": 200,
  "data": "성공적으로 저장되었습니다."
}
```

- 감정 도감 API 를 구현완료했습니다
- /statistics/collection
```
{
  "status": 200,
  "data": {
    "totalEmotionCount": 414,
    "categoryStats": {
      "기쁨": {
        "totalCount": 67,
        "usedCount": 2
      }
    },
    "usedEmotionCount": 2
  }
}
```
- totalEmotionCount: 전체 감정의 개수
- usedEmotionCount: 사용한 감정의 개수
- categoryStats: 카테고리별 통계
