### PR TITLE
Fix Java executable not found error with multi-stage Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,30 @@
-# 1. Java 17의 Eclipse Temurin 이미지 사용 (OpenJDK 공식 후속)
-FROM eclipse-temurin:17-jdk-jammy
+# Stage 1: Build
+FROM eclipse-temurin:17-jdk-jammy AS builder
 
-# 2. 작업 디렉토리 생성 및 설정
+# 작업 디렉토리 생성 및 설정
 WORKDIR /app
 
-# 3. build.gradle, gradlew, 그리고 필요한 파일 복사
+# build.gradle, gradlew, 그리고 필요한 파일 복사
 COPY build.gradle /app/
 COPY gradlew /app/
 COPY gradle /app/gradle
 COPY src /app/src
 
-# 4. gradlew에 실행 권한 부여 및 Gradle로 프로젝트 빌드
+# gradlew에 실행 권한 부여 및 Gradle로 프로젝트 빌드
 RUN chmod +x ./gradlew
 RUN ./gradlew bootJar
-RUN mv build/libs/*.jar build/libs/app.jar
 
-# 5. 빌드 결과를 어플리케이션으로 설정
+# Stage 2: Runtime
+FROM eclipse-temurin:17-jre-jammy
+
+# 작업 디렉토리 생성
+WORKDIR /app
+
+# 빌드 결과 복사
+COPY --from=builder /app/build/libs/*.jar /app/app.jar
+
+# 포트 노출
 EXPOSE 7010
-ENTRYPOINT ["java", "-jar", "build/libs/app.jar"]
+
+# 애플리케이션 실행
+ENTRYPOINT ["java", "-jar", "/app/app.jar"]


### PR DESCRIPTION
- Split build into two stages: builder (JDK) and runtime (JRE)
- Use JRE image for runtime to reduce image size
- Explicitly specify JAR file path in ENTRYPOINT
- This resolves the "java: executable file not found in $PATH" error