### PR TITLE
Fix CORS configuration for API network errors

### DIFF
--- a/src/main/java/com/example/aneukbeserver/config/CorsConfig.java
+++ b/src/main/java/com/example/aneukbeserver/config/CorsConfig.java
@@ -12,11 +12,16 @@ public class CorsConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.addAllowedOrigin("http://localhost:3000"); // 허용할 출처
-        configuration.addAllowedOrigin("http://43.203.232.54:2518"); // 허용할 출처
-        configuration.addAllowedOrigin("https://aneuk-api.dev-lr.com"); // 허용할 출처
-        configuration.addAllowedOrigin("https://aneuk.dev-lr.com"); // 허용할 출처
-        configuration.addAllowedMethod("*");
+        configuration.addAllowedOrigin("http://localhost:3000");
+        configuration.addAllowedOrigin("http://43.203.232.54:2518");
+        configuration.addAllowedOrigin("https://aneuk-api.dev-lr.com");
+        configuration.addAllowedOrigin("https://aneuk.dev-lr.com");
+        configuration.addAllowedMethod("GET");
+        configuration.addAllowedMethod("POST");
+        configuration.addAllowedMethod("PUT");
+        configuration.addAllowedMethod("PATCH");
+        configuration.addAllowedMethod("DELETE");
+        configuration.addAllowedMethod("OPTIONS");
         configuration.addAllowedHeader("*");
         configuration.setAllowCredentials(true);
 

--- a/src/main/java/com/example/aneukbeserver/config/SecurityConfig.java
+++ b/src/main/java/com/example/aneukbeserver/config/SecurityConfig.java
@@ -11,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -36,6 +37,7 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
+                .cors(Customizer.withDefaults()) // CORS 활성화
                 .csrf(AbstractHttpConfigurer::disable) // CSRF 보호 기능 비활성화
                 .authorizeHttpRequests(authorizeRequests ->
                         authorizeRequests

--- a/src/main/java/com/example/aneukbeserver/config/WebConfig.java
+++ b/src/main/java/com/example/aneukbeserver/config/WebConfig.java
@@ -9,11 +9,13 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOrigins("http://localhost:3000")  // 정확한 클라이언트 오리진 지정
-                .allowedOrigins("http://43.203.232.54:2518")
-                .allowedOrigins("https://aneuk-api.dev-lr.com")
-                .allowedOrigins("https://aneuk.dev-lr.com")
-                .allowedMethods("GET", "POST", "OPTIONS")
+                .allowedOrigins(
+                        "http://localhost:3000",
+                        "http://43.203.232.54:2518",
+                        "https://aneuk-api.dev-lr.com",
+                        "https://aneuk.dev-lr.com"
+                )
+                .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
                 .allowCredentials(true)
                 .allowedHeaders("*")
                 .maxAge(3600);


### PR DESCRIPTION
- Enable CORS in SecurityConfig with Customizer.withDefaults()
- Fix WebConfig allowedOrigins to use array instead of multiple calls
- Add missing HTTP methods (PUT, PATCH, DELETE) to allowed methods
- Update CorsConfig to include all necessary HTTP methods

This resolves "Network Error" when frontend calls backend API.