### PR TITLE
Support provider-specific OAuth success redirects

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# OAuth2 success redirect URIs for each provider
+AUTH_SUCCESS_REDIRECT_GOOGLE=http://localhost:3000/oauth2/google
+AUTH_SUCCESS_REDIRECT_KAKAO=http://localhost:3000/oauth2/kakao
+AUTH_SUCCESS_REDIRECT_NAVER=http://localhost:3000/oauth2/naver

--- a/src/main/java/com/example/aneukbeserver/auth/handler/MyAuthenticationSuccessHandler.java
+++ b/src/main/java/com/example/aneukbeserver/auth/handler/MyAuthenticationSuccessHandler.java
@@ -7,10 +7,10 @@ import com.example.aneukbeserver.domain.member.MemberRepository;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
@@ -20,18 +20,41 @@ import java.io.IOException;
 
 @Slf4j
 @Component
-@RequiredArgsConstructor
 // OAuth2 인정에 성공했을 경우 성공 처리
 public class MyAuthenticationSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
     private final JwtUtil jwtUtil;
 
     private final MemberRepository memberRepository;
 
-    @Value("${spring.jwt.success-redirect:http://localhost:3000}")
-    private String redirectUri;
+    private final String googleRedirectUri;
+
+    private final String kakaoRedirectUri;
+
+    private final String naverRedirectUri;
+
+    public MyAuthenticationSuccessHandler(
+            JwtUtil jwtUtil,
+            MemberRepository memberRepository,
+            @Value("${spring.jwt.success-redirect.google:http://localhost:3000}") String googleRedirectUri,
+            @Value("${spring.jwt.success-redirect.kakao:http://localhost:3000}") String kakaoRedirectUri,
+            @Value("${spring.jwt.success-redirect.naver:http://localhost:3000}") String naverRedirectUri) {
+        this.jwtUtil = jwtUtil;
+        this.memberRepository = memberRepository;
+        this.googleRedirectUri = googleRedirectUri;
+        this.kakaoRedirectUri = kakaoRedirectUri;
+        this.naverRedirectUri = naverRedirectUri;
+    }
 
     @Override
-    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication)
+            throws IOException, ServletException {
+        if (!(authentication instanceof OAuth2AuthenticationToken)) {
+            log.warn("Unsupported authentication type: {}", authentication.getClass().getSimpleName());
+            super.onAuthenticationSuccess(request, response, authentication);
+            return;
+        }
+
+        OAuth2AuthenticationToken oauthToken = (OAuth2AuthenticationToken) authentication;
         OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
         String email = oAuth2User.getAttribute("email");
         String role = oAuth2User.getAuthorities().stream()
@@ -53,6 +76,8 @@ public class MyAuthenticationSuccessHandler extends SimpleUrlAuthenticationSucce
         GeneratedToken token = jwtUtil.generateToken(email, role);
         log.info("JWT Token = {}", token.getAccessToken());
 
+        String redirectUri = resolveRedirectUri(oauthToken.getAuthorizedClientRegistrationId());
+
         // 이메일과 인코딩된 액세스 토큰을 쿼리 파라미터로 추가
         String targetUrl = UriComponentsBuilder.fromUriString(redirectUri)
                 .queryParam("email", email)
@@ -65,6 +90,25 @@ public class MyAuthenticationSuccessHandler extends SimpleUrlAuthenticationSucce
         // 리디렉션
         getRedirectStrategy().sendRedirect(request, response, targetUrl);
 
+    }
+
+    private String resolveRedirectUri(String registrationId) {
+        if (registrationId == null) {
+            log.warn("Registration ID is null. Falling back to Google redirect URI.");
+            return googleRedirectUri;
+        }
+
+        switch (registrationId.toLowerCase()) {
+            case "kakao":
+                return kakaoRedirectUri;
+            case "naver":
+                return naverRedirectUri;
+            case "google":
+                return googleRedirectUri;
+            default:
+                log.warn("Unknown registration ID: {}. Falling back to Google redirect URI.", registrationId);
+                return googleRedirectUri;
+        }
     }
 
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,7 +10,10 @@ spring:
 
   jwt:
     secret: ${JWT_SECRET}
-    success-redirect: ${AUTH_SUCCESS_REDIRECT}
+    success-redirect:
+      google: ${AUTH_SUCCESS_REDIRECT_GOOGLE}
+      kakao: ${AUTH_SUCCESS_REDIRECT_KAKAO}
+      naver: ${AUTH_SUCCESS_REDIRECT_NAVER}
 
   security:
     oauth2:


### PR DESCRIPTION
## Summary
- add dedicated success redirect environment variables per OAuth provider
- expose the provider-specific redirect URIs through Spring configuration
- route users to the configured redirect based on the OAuth2 registration id

## Testing
- ./gradlew test *(fails: unable to download Gradle due to proxy restrictions)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915dbbb4464832d9df72fa11b6b058d)